### PR TITLE
build: add default version in revision property

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -47,6 +47,9 @@ jobs:
       with:
          distribution: 'adopt'
          java-version: '11'
+
+    - name: Check Maven version
+      run: mvn -version
          
     - name: Update Version in pom.xml
       run: mvn -B versions:set -DnewVersion=${{ github.event.inputs.packageVersion }} -DgenerateBackupPoms=false

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     </distributionManagement>
 
     <properties>
+        <revision>1.0.0</revision>
         <maven.test.skip>true</maven.test.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
@mir-huzaif mvn now requires that the revision property be defined with a constant value in the POM file, rather than just being a placeholder.